### PR TITLE
Crypto Layer refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,7 @@ include (CheckCCompilerFlag)
 # All targets obey visibility, not just library targets.
 cmake_policy (SET CMP0063 NEW)
 set (CMAKE_C_VISIBILITY_PRESET hidden)
-add_library (
-   kms_message SHARED
+set (KMS_MESSAGE_SOURCES
    src/b64.c
    src/b64.h
    src/hexlify.c
@@ -37,6 +36,10 @@ add_library (
    src/kms_request_str.h
    src/kms_response.c
    src/kms_response_parser.c
+   )
+add_library (
+   kms_message SHARED
+   ${KMS_MESSAGE_SOURCES}
 )
 
 include (FindOpenSSL)
@@ -125,11 +128,9 @@ install (
 
 add_executable (
    test_kms_request
-   src/b64.c
-   src/hexlify.c
-   src/kms_kv_list.c
+   ${KMS_MESSAGE_SOURCES}
    test/test_kms_request.c
 )
 
-target_link_libraries (test_kms_request kms_message)
-target_include_directories (test_kms_request PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(test_kms_request "${OPENSSL_LIBRARIES}")
+target_include_directories(test_kms_request PRIVATE "${OPENSSL_INCLUDE_DIR}" ${PROJECT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,9 +127,7 @@ add_executable (
    test_kms_request
    src/b64.c
    src/hexlify.c
-   src/kms_encrypt_request.c
    src/kms_kv_list.c
-   src/kms_message.c
    test/test_kms_request.c
 )
 

--- a/src/kms_crypto.c
+++ b/src/kms_crypto.c
@@ -36,6 +36,17 @@ EVP_MD_CTX_free (EVP_MD_CTX *ctx)
 }
 #endif
 
+int
+kms_crypto_init ()
+{
+   return 0;
+}
+
+void
+kms_crypto_cleanup ()
+{
+}
+
 bool
 kms_sha256 (const char *input, size_t len, unsigned char *hash_out)
 {
@@ -56,4 +67,20 @@ cleanup:
    EVP_MD_CTX_free (digest_ctxp);
 
    return rval;
+}
+
+bool
+kms_sha256_hmac (const char *key_input,
+                 size_t key_len,
+                 const char *input,
+                 size_t len,
+                 unsigned char *hash_out)
+{
+   return HMAC (EVP_sha256 (),
+                key_input,
+                key_len,
+                (unsigned char *) input,
+                len,
+                hash_out,
+                NULL) != NULL;
 }

--- a/src/kms_crypto.h
+++ b/src/kms_crypto.h
@@ -20,7 +20,20 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+int
+kms_crypto_init ();
+
+void
+kms_crypto_cleanup ();
+
 bool
 kms_sha256 (const char *input, size_t len, unsigned char *hash_out);
+
+bool
+kms_sha256_hmac (const char *key_input,
+                 size_t key_len,
+                 const char *input,
+                 size_t len,
+                 unsigned char *hash_out);
 
 #endif /* KMS_MESSAGE_KMS_CRYPTO_H */

--- a/src/kms_message.c
+++ b/src/kms_message.c
@@ -18,6 +18,7 @@
 #include "b64.h"
 #include "kms_message/kms_message.h"
 #include "kms_message_private.h"
+#include "kms_crypto.h"
 
 #include <stdarg.h>
 #include <stdio.h>
@@ -32,14 +33,15 @@ set_error (char *error, size_t size, const char *fmt, ...)
    va_end (va);
 }
 
-void
+int
 kms_message_init (void)
 {
    kms_message_b64_initialize_rmap ();
+   return kms_crypto_init ();
 }
 
 void
 kms_message_cleanup (void)
 {
-   /* nothing yet */
+   kms_crypto_cleanup ();
 }

--- a/src/kms_message/kms_message_defines.h
+++ b/src/kms_message/kms_message_defines.h
@@ -40,7 +40,7 @@
 
 #define KMS_MSG_EXPORT(type) KMS_MSG_API type KMS_MSG_CALL
 
-KMS_MSG_EXPORT (void)
+KMS_MSG_EXPORT (int)
 kms_message_init (void);
 KMS_MSG_EXPORT (void)
 kms_message_cleanup (void);

--- a/src/kms_request_str.c
+++ b/src/kms_request_str.c
@@ -24,8 +24,6 @@
 #include <ctype.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
 
 bool rfc_3986_tab[256] = {0};
 bool kms_initialized = false;

--- a/test/test_kms_request.c
+++ b/test/test_kms_request.c
@@ -749,7 +749,11 @@ main (int argc, char *argv[])
       selector = argv[1];
    }
 
-   kms_message_init ();
+   int ret = kms_message_init ();
+   if (ret != 0) {
+      printf ("kms_message_init failed: 0x%x\n", ret);
+      abort ();
+   }
 
    RUN_TEST (example_signature_test);
    RUN_TEST (path_normalization_test);

--- a/test/test_kms_request.c
+++ b/test/test_kms_request.c
@@ -749,8 +749,6 @@ main (int argc, char *argv[])
       selector = argv[1];
    }
 
-   kms_message_b64_initialize_rmap ();
-
    int ret = kms_message_init ();
    if (ret != 0) {
       printf ("kms_message_init failed: 0x%x\n", ret);

--- a/test/test_kms_request.c
+++ b/test/test_kms_request.c
@@ -749,6 +749,8 @@ main (int argc, char *argv[])
       selector = argv[1];
    }
 
+   kms_message_b64_initialize_rmap ();
+
    int ret = kms_message_init ();
    if (ret != 0) {
       printf ("kms_message_init failed: 0x%x\n", ret);


### PR DESCRIPTION
Make KMS code independent of openssl and hide all the code in
kms_crypto.c.

I will in a later CR probably renamed kms_crypto.c to kms_crypto_openssl.c.

kms_crypto_init has a return code since Windows requires initialization so I introduced it now.